### PR TITLE
Versioning fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,24 +118,27 @@ module "setup" {
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ars_sa"></a> [ars\_sa](#module\_ars\_sa) | github.com/Coalfire-CF/terraform-azurerm-storage-account | n/a |
-| <a name="module_diag_cloudshell_sa"></a> [diag\_cloudshell\_sa](#module\_diag\_cloudshell\_sa) | github.com/Coalfire-CF/terraform-azurerm-diagnostics | n/a |
-| <a name="module_docs_sa"></a> [docs\_sa](#module\_docs\_sa) | github.com/Coalfire-CF/terraform-azurerm-storage-account | n/a |
-| <a name="module_flowlogs_sa"></a> [flowlogs\_sa](#module\_flowlogs\_sa) | github.com/Coalfire-CF/terraform-azurerm-storage-account | n/a |
-| <a name="module_installs_sa"></a> [installs\_sa](#module\_installs\_sa) | github.com/Coalfire-CF/terraform-azurerm-storage-account | n/a |
-| <a name="module_vm_diag"></a> [vm\_diag](#module\_vm\_diag) | github.com/Coalfire-CF/terraform-azurerm-storage-account | n/a |
+| <a name="module_ars_sa"></a> [ars\_sa](#module\_ars\_sa) | github.com/Coalfire-CF/terraform-azurerm-storage-account | v1.0.1 |
+| <a name="module_diag_cloudshell_sa"></a> [diag\_cloudshell\_sa](#module\_diag\_cloudshell\_sa) | github.com/Coalfire-CF/terraform-azurerm-diagnostics | v1.0.0 |
+| <a name="module_docs_sa"></a> [docs\_sa](#module\_docs\_sa) | github.com/Coalfire-CF/terraform-azurerm-storage-account | v1.0.1 |
+| <a name="module_flowlogs_sa"></a> [flowlogs\_sa](#module\_flowlogs\_sa) | github.com/Coalfire-CF/terraform-azurerm-storage-account | v1.0.1 |
+| <a name="module_installs_sa"></a> [installs\_sa](#module\_installs\_sa) | github.com/Coalfire-CF/terraform-azurerm-storage-account | v1.0.1 |
+| <a name="module_vm_diag"></a> [vm\_diag](#module\_vm\_diag) | github.com/Coalfire-CF/terraform-azurerm-storage-account | v1.0.1 |
 
 ## Resources
 
@@ -158,12 +161,10 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_resource_groups"></a> [additional\_resource\_groups](#input\_additional\_resource\_groups) | Additional resource groups to create | `list(string)` | `[]` | no |
-| <a name="input_admin_principal_ids"></a> [admin\_principal\_ids](#input\_admin\_principal\_ids) | List of principal ID's for all admins | `set(string)` | n/a | yes |
 | <a name="input_app_abbreviation"></a> [app\_abbreviation](#input\_app\_abbreviation) | The prefix for the blob storage account names | `string` | n/a | yes |
 | <a name="input_app_rg_name"></a> [app\_rg\_name](#input\_app\_rg\_name) | Application plane resource group name | `string` | `"application-rg-1"` | no |
 | <a name="input_core_kv_id"></a> [core\_kv\_id](#input\_core\_kv\_id) | n/a | `string` | n/a | yes |
 | <a name="input_diag_log_analytics_id"></a> [diag\_log\_analytics\_id](#input\_diag\_log\_analytics\_id) | ID of the Log Analytics Workspace diagnostic logs should be sent to | `string` | n/a | yes |
-| <a name="input_firewall_vnet_subnet_ids"></a> [firewall\_vnet\_subnet\_ids](#input\_firewall\_vnet\_subnet\_ids) | Subnet ID's that should be allowed for the firewall | `list(string)` | `[]` | no |
 | <a name="input_fw_virtual_network_subnet_ids"></a> [fw\_virtual\_network\_subnet\_ids](#input\_fw\_virtual\_network\_subnet\_ids) | List of subnet ids for the firewall | `list(string)` | `[]` | no |
 | <a name="input_global_tags"></a> [global\_tags](#input\_global\_tags) | Global level tags | `map(string)` | n/a | yes |
 | <a name="input_ip_for_remote_access"></a> [ip\_for\_remote\_access](#input\_ip\_for\_remote\_access) | This is the same as 'cidrs\_for\_remote\_access' but without the /32 on each of the files. The 'ip\_rules' in the storage account will not accept a '/32' address and I gave up trying to strip and convert the values over | `list(any)` | n/a | yes |
@@ -176,8 +177,6 @@ No requirements.
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Name prefix used for resources | `string` | n/a | yes |
 | <a name="input_sas_end_date"></a> [sas\_end\_date](#input\_sas\_end\_date) | value | `string` | n/a | yes |
 | <a name="input_sas_start_date"></a> [sas\_start\_date](#input\_sas\_start\_date) | value | `string` | n/a | yes |
-| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The Azure subscription ID where resources are being deployed into | `string` | n/a | yes |
-| <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | The Azure tenant ID that owns the deployed resources | `string` | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -86,12 +86,10 @@ provider "azurerm" {
 module "setup" {
   source = "github.com/Coalfire-CF/terraform-azurerm-region-setup"
 
-  subscription_id       = var.subscription_id
   location_abbreviation = var.location_abbreviation
   location              = var.location
   resource_prefix       = local.resource_prefix
   app_abbreviation      = var.app_abbreviation
-  tenant_id             = var.tenant_id
   regional_tags         = var.regional_tags
   global_tags           = merge(var.global_tags, local.global_local_tags)
   mgmt_rg_name          = "${local.resource_prefix}-management-rg"
@@ -103,10 +101,6 @@ module "setup" {
   ip_for_remote_access  = var.ip_for_remote_access
   core_kv_id            = data.terraform_remote_state.core.outputs.core_kv_id
   diag_log_analytics_id = data.terraform_remote_state.core.outputs.core_la_id
-  admin_principal_ids   = var.admin_principal_ids
-
-  # uncomment the following line when the mgmt-network is created
-  #firewall_vnet_subnet_ids = values(data.terraform_remote_state.usgv_mgmt_vnet.outputs.usgv_mgmt_vnet_subnet_ids) #Uncomment and rerun terraform apply after the mgmt-network is created
   
   additional_resource_groups = [
     "${local.resource_prefix}-identity-rg"

--- a/blob_ars.tf
+++ b/blob_ars.tf
@@ -1,5 +1,5 @@
 module "ars_sa" {
-  source                = "github.com/Coalfire-CF/terraform-azurerm-storage-account"
+  source                = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
   name                  = "${replace(var.resource_prefix, "-", "")}saarsvault"
   resource_group_name   = azurerm_resource_group.management.name
   location              = var.location

--- a/blob_docs.tf
+++ b/blob_docs.tf
@@ -1,5 +1,5 @@
 module "docs_sa" {
-  source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account"
+  source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
   name                       = "${replace(var.resource_prefix, "-", "")}docs"
   resource_group_name        = azurerm_resource_group.management.name
   location                   = var.location

--- a/blob_flowlog.tf
+++ b/blob_flowlog.tf
@@ -1,5 +1,5 @@
 module "flowlogs_sa" {
-  source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account"
+  source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
   name                       = "${replace(var.resource_prefix, "-", "")}saflowlogs"
   resource_group_name        = azurerm_resource_group.management.name
   location                   = var.location

--- a/blob_install.tf
+++ b/blob_install.tf
@@ -1,5 +1,5 @@
 module "installs_sa" {
-  source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account"
+  source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
   name                       = "${replace(var.resource_prefix, "-", "")}sainstalls"
   resource_group_name        = azurerm_resource_group.management.name
   location                   = var.location

--- a/blob_vm_diag.tf
+++ b/blob_vm_diag.tf
@@ -1,5 +1,5 @@
 module "vm_diag" {
-  source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account"
+  source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
   name                       = "${replace(var.resource_prefix, "-", "")}savmdiag"
   resource_group_name        = azurerm_resource_group.management.name
   location                   = var.location

--- a/required_providers.tf
+++ b/required_providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/share_cloudshell.tf
+++ b/share_cloudshell.tf
@@ -5,7 +5,7 @@ resource "azurerm_storage_account" "cloudShell" {
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
   account_kind                    = "StorageV2"
-  enable_https_traffic_only       = true
+  https_traffic_only_enabled      = true
   allow_nested_items_to_be_public = false
 
   lifecycle {
@@ -28,7 +28,7 @@ resource "azurerm_storage_account" "cloudShell" {
 resource "azurerm_role_assignment" "tstate_kv_crypto_user_cloudshell" {
   scope                = var.core_kv_id
   role_definition_name = "Key Vault Crypto Service Encryption User"
-  principal_id         = azurerm_storage_account.cloudShell.identity.0.principal_id
+  principal_id         = azurerm_storage_account.cloudShell.identity[0].principal_id
 
   depends_on = [
     azurerm_storage_account.cloudShell
@@ -46,7 +46,7 @@ resource "azurerm_storage_account_customer_managed_key" "enable_cloudShell_cmk" 
 }
 
 module "diag_cloudshell_sa" {
-  source                = "github.com/Coalfire-CF/terraform-azurerm-diagnostics"
+  source                = "github.com/Coalfire-CF/terraform-azurerm-diagnostics?ref=v1.0.0"
   diag_log_analytics_id = var.diag_log_analytics_id
   resource_id           = azurerm_storage_account.cloudShell.id
   resource_type         = "sa"

--- a/variables.tf
+++ b/variables.tf
@@ -23,21 +23,6 @@ variable "app_abbreviation" {
   type        = string
 }
 
-variable "subscription_id" {
-  description = "The Azure subscription ID where resources are being deployed into"
-  type        = string
-}
-
-variable "tenant_id" {
-  description = "The Azure tenant ID that owns the deployed resources"
-  type        = string
-}
-
-# variable "sub_diag_logs" {
-#   description = "Types of logs to gather for subscription diagnostics"
-#   type        = list(any)
-# }
-
 variable "mgmt_rg_name" {
   description = "Management plane resource group name"
   type        = string
@@ -72,18 +57,6 @@ variable "sas_end_date" {
   type        = string
 }
 
-# variable "create_monitor" {
-#   description = "Whether or not to create Azure Monitor resources"
-#   type        = bool
-# }
-
-variable "firewall_vnet_subnet_ids" {
-  description = "Subnet ID's that should be allowed for the firewall"
-  type        = list(string)
-  #default     = null
-  default = [] #testing 
-}
-
 variable "fw_virtual_network_subnet_ids" {
   type        = list(string)
   description = "List of subnet ids for the firewall"
@@ -107,11 +80,6 @@ variable "diag_log_analytics_id" {
 variable "resource_prefix" {
   type        = string
   description = "Name prefix used for resources"
-}
-
-variable "admin_principal_ids" {
-  type        = set(string)
-  description = "List of principal ID's for all admins"
 }
 
 variable "additional_resource_groups" {


### PR DESCRIPTION
- Added tag reference to module calls (usually "?ref=v1.0.X").  Terraform linting will call this out.  This increases code stability.
- Added required version pinning (linting).  Sometimes you wrote code using a specific provider version (3.0), if you don't pin the versions, that could allow deprecated or renamed parameters in resources.
  - azurerm_storage_account.cloudShell has one example where "enable_https_traffic_only" changed to "https_traffic_only_enabled" from azurerm 3.0 => 4.0.  The "terraform-azurerm-storage-account" pak uses the latter (4.0), but the former was used for that specific resource, leading the module to not work.  I updated the parameter and added a required_providers block to indicate what version of the provider I ran the code with (latest of azurerm 4.X)
- Linting fix, changed "azurerm_storage_account.cloudShell.identity.0.principal_id" => "azurerm_storage_account.cloudShell.identity[0].principal_id".  The former is a deprecated method of referencing a list item.
- Linting fix, removed variables that were declared but never used anywhere in the pak code:
  - subscription_id
  - tenant_id
  - firewall_vnet_subnet_ids
  - admin_principal_ids

The updated code was used to deploy resources in Precisely.