### PR TITLE
Accept optional custom names for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,20 +179,28 @@ module "setup" {
 | <a name="input_additional_resource_groups"></a> [additional\_resource\_groups](#input\_additional\_resource\_groups) | Additional resource groups to create | `list(string)` | `[]` | no |
 | <a name="input_app_abbreviation"></a> [app\_abbreviation](#input\_app\_abbreviation) | The prefix for the blob storage account names | `string` | n/a | yes |
 | <a name="input_app_rg_name"></a> [app\_rg\_name](#input\_app\_rg\_name) | Application plane resource group name | `string` | `"application-rg-1"` | no |
+| <a name="input_ars_storageaccount_name"></a> [ars\_storageaccount\_name](#input\_ars\_storageaccount\_name) | (Optional) Custom name for the ars Storage Account | `string` | `"default"` | no |
+| <a name="input_cloudshell_storageaccount_name"></a> [cloudshell\_storageaccount\_name](#input\_cloudshell\_storageaccount\_name) | (Optional) Custom name for the Cloudshell Storage Account | `string` | `"default"` | no |
+| <a name="input_compute_gallery_name"></a> [compute\_gallery\_name](#input\_compute\_gallery\_name) | (Optional) Custom name for the Azure Compute Gallery (Shared Image Gallery) | `string` | `"default"` | no |
 | <a name="input_core_kv_id"></a> [core\_kv\_id](#input\_core\_kv\_id) | n/a | `string` | n/a | yes |
 | <a name="input_diag_log_analytics_id"></a> [diag\_log\_analytics\_id](#input\_diag\_log\_analytics\_id) | ID of the Log Analytics Workspace diagnostic logs should be sent to | `string` | n/a | yes |
+| <a name="input_docs_storageaccount_name"></a> [docs\_storageaccount\_name](#input\_docs\_storageaccount\_name) | (Optional) Custom name for the Documents Storage Account | `string` | `"default"` | no |
+| <a name="input_flowlogs_storageaccount_name"></a> [flowlogs\_storageaccount\_name](#input\_flowlogs\_storageaccount\_name) | (Optional) Custom name for the Flow Logs Storage Account | `string` | `"default"` | no |
 | <a name="input_fw_virtual_network_subnet_ids"></a> [fw\_virtual\_network\_subnet\_ids](#input\_fw\_virtual\_network\_subnet\_ids) | List of subnet ids for the firewall | `list(string)` | `[]` | no |
 | <a name="input_global_tags"></a> [global\_tags](#input\_global\_tags) | Global level tags | `map(string)` | n/a | yes |
+| <a name="input_installs_storageaccount_name"></a> [installs\_storageaccount\_name](#input\_installs\_storageaccount\_name) | (Optional) Custom name for the Installs Storage Account | `string` | `"default"` | no |
 | <a name="input_ip_for_remote_access"></a> [ip\_for\_remote\_access](#input\_ip\_for\_remote\_access) | This is the same as 'cidrs\_for\_remote\_access' but without the /32 on each of the files. The 'ip\_rules' in the storage account will not accept a '/32' address and I gave up trying to strip and convert the values over | `list(any)` | n/a | yes |
 | <a name="input_key_vault_rg_name"></a> [key\_vault\_rg\_name](#input\_key\_vault\_rg\_name) | Key Vault resource group name | `string` | `"keyvault-rg-01"` | no |
 | <a name="input_location"></a> [location](#input\_location) | The Azure location/region to create resources in | `string` | n/a | yes |
 | <a name="input_location_abbreviation"></a> [location\_abbreviation](#input\_location\_abbreviation) | The  Azure location/region in 4 letter code | `string` | n/a | yes |
 | <a name="input_mgmt_rg_name"></a> [mgmt\_rg\_name](#input\_mgmt\_rg\_name) | Management plane resource group name | `string` | `"management-rg-1"` | no |
+| <a name="input_network_watcher_name"></a> [network\_watcher\_name](#input\_network\_watcher\_name) | (Optional) Custom name for the Azure Network Watcher | `string` | `"default"` | no |
 | <a name="input_networking_rg_name"></a> [networking\_rg\_name](#input\_networking\_rg\_name) | Networking resource group name | `string` | `"networking-rg-01"` | no |
 | <a name="input_regional_tags"></a> [regional\_tags](#input\_regional\_tags) | Regional level tags | `map(string)` | n/a | yes |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Name prefix used for resources | `string` | n/a | yes |
 | <a name="input_sas_end_date"></a> [sas\_end\_date](#input\_sas\_end\_date) | value | `string` | n/a | yes |
 | <a name="input_sas_start_date"></a> [sas\_start\_date](#input\_sas\_start\_date) | value | `string` | n/a | yes |
+| <a name="input_vmdiag_storageaccount_name"></a> [vmdiag\_storageaccount\_name](#input\_vmdiag\_storageaccount\_name) | (Optional) Custom name for the VM Diagnostic Logs Storage Account | `string` | `"default"` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,28 @@ module "setup" {
 
 ```
 
+
+### Optional - custom resource names
+You may optionally supply custom names for all resources created by this module, to support various naming convention requirements: 
+
+```hcl
+module "setup" {
+...
+  compute_gallery_name           = "computegallery01"
+  cloudshell_storageaccount_name = "usgovcloudshellsa"
+  ars_storageaccount_name        = "usgovarssa"
+  docs_storageaccount_name       = "usgovdocssa" 
+  flowlogs_storageaccount_name   = "usgovflowlogssa"
+  installs_storageaccount_name   = "usgovinstallssa"
+  vmdiag_storageaccount_name     = "usgovdiagsa"
+  network_watcher_name           = "usgovnetworkwatcher"
+...
+}
+
+```
+
+
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/blob_ars.tf
+++ b/blob_ars.tf
@@ -1,6 +1,6 @@
 module "ars_sa" {
   source                = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
-  name                  = var.ars_storageaccount_name
+  name                  = local.ars_storageaccount_name
   resource_group_name   = azurerm_resource_group.management.name
   location              = var.location
   account_kind          = "StorageV2"

--- a/blob_ars.tf
+++ b/blob_ars.tf
@@ -1,6 +1,6 @@
 module "ars_sa" {
   source                = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
-  name                  = "${replace(var.resource_prefix, "-", "")}saarsvault"
+  name                  = var.ars_storageaccount_name
   resource_group_name   = azurerm_resource_group.management.name
   location              = var.location
   account_kind          = "StorageV2"

--- a/blob_docs.tf
+++ b/blob_docs.tf
@@ -1,6 +1,6 @@
 module "docs_sa" {
   source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
-  name                       = var.docs_storageaccount_name
+  name                       = local.docs_storageaccount_name
   resource_group_name        = azurerm_resource_group.management.name
   location                   = var.location
   account_kind               = "StorageV2"

--- a/blob_docs.tf
+++ b/blob_docs.tf
@@ -1,6 +1,6 @@
 module "docs_sa" {
   source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
-  name                       = "${replace(var.resource_prefix, "-", "")}docs"
+  name                       = var.docs_storageaccount_name
   resource_group_name        = azurerm_resource_group.management.name
   location                   = var.location
   account_kind               = "StorageV2"

--- a/blob_flowlog.tf
+++ b/blob_flowlog.tf
@@ -1,6 +1,6 @@
 module "flowlogs_sa" {
   source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
-  name                       = "${replace(var.resource_prefix, "-", "")}saflowlogs"
+  name                       = var.flowlogs_storageaccount_name
   resource_group_name        = azurerm_resource_group.management.name
   location                   = var.location
   account_kind               = "StorageV2"

--- a/blob_flowlog.tf
+++ b/blob_flowlog.tf
@@ -1,6 +1,6 @@
 module "flowlogs_sa" {
   source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
-  name                       = var.flowlogs_storageaccount_name
+  name                       = local.flowlogs_storageaccount_name
   resource_group_name        = azurerm_resource_group.management.name
   location                   = var.location
   account_kind               = "StorageV2"

--- a/blob_install.tf
+++ b/blob_install.tf
@@ -1,6 +1,6 @@
 module "installs_sa" {
   source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
-  name                       = "${replace(var.resource_prefix, "-", "")}sainstalls"
+  name                       = var.installs_storageaccount_name
   resource_group_name        = azurerm_resource_group.management.name
   location                   = var.location
   account_kind               = "StorageV2"

--- a/blob_install.tf
+++ b/blob_install.tf
@@ -1,6 +1,6 @@
 module "installs_sa" {
   source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
-  name                       = var.installs_storageaccount_name
+  name                       = local.installs_storageaccount_name
   resource_group_name        = azurerm_resource_group.management.name
   location                   = var.location
   account_kind               = "StorageV2"

--- a/blob_vm_diag.tf
+++ b/blob_vm_diag.tf
@@ -1,6 +1,6 @@
 module "vm_diag" {
   source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
-  name                       = var.vmdiag_storageaccount_name
+  name                       = local.vmdiag_storageaccount_name
   resource_group_name        = azurerm_resource_group.management.name
   location                   = var.location
   account_kind               = "StorageV2"

--- a/blob_vm_diag.tf
+++ b/blob_vm_diag.tf
@@ -1,6 +1,6 @@
 module "vm_diag" {
   source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
-  name                       = "${replace(var.resource_prefix, "-", "")}savmdiag"
+  name                       = var.vmdiag_storageaccount_name
   resource_group_name        = azurerm_resource_group.management.name
   location                   = var.location
   account_kind               = "StorageV2"

--- a/image_gallery.tf
+++ b/image_gallery.tf
@@ -1,5 +1,5 @@
 resource "azurerm_shared_image_gallery" "marketplaceimages" {
-  name                = var.compute_gallery_name
+  name                = local.compute_gallery_name
   resource_group_name = azurerm_resource_group.management.name
   location            = var.location
   description         = "Images for FedRAMP Environment"

--- a/image_gallery.tf
+++ b/image_gallery.tf
@@ -1,5 +1,5 @@
 resource "azurerm_shared_image_gallery" "marketplaceimages" {
-  name                = "${replace(var.resource_prefix, "-", "_")}_imagegallery_1"
+  name                = var.compute_gallery_name
   resource_group_name = azurerm_resource_group.management.name
   location            = var.location
   description         = "Images for FedRAMP Environment"

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,13 @@
 locals {
   storage_name_prefix = replace(var.resource_prefix, "-", "")
+
+  # Default names for resources
+  default_compute_gallery_name           = "${replace(var.resource_prefix, "-", "_")}_imagegallery_1"
+  default_cloudshell_storageaccount_name = length("${local.storage_name_prefix}sacloudshell") <= 24 ? "${local.storage_name_prefix}sacloudshell" : "${var.location_abbreviation}mp${var.app_abbreviation}sacloudshell"
+  default_ars_storageaccount_name        = "${replace(var.resource_prefix, "-", "")}saarsvault"
+  default_docs_storageaccount_name       = "${replace(var.resource_prefix, "-", "")}docs"
+  default_flowlogs_storageaccount_name   = "${replace(var.resource_prefix, "-", "")}saflowlogs"
+  default_installs_storageaccount_name   = "${replace(var.resource_prefix, "-", "")}sainstalls"
+  default_vmdiag_storageaccount_name     = "${replace(var.resource_prefix, "-", "")}savmdiag"
+  default_network_watcher_name           = "${replace(var.resource_prefix, "-", "_")}_netw_watcher"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -2,12 +2,12 @@ locals {
   storage_name_prefix = replace(var.resource_prefix, "-", "")
 
   # Default names for resources
-  default_compute_gallery_name           = "${replace(var.resource_prefix, "-", "_")}_imagegallery_1"
-  default_cloudshell_storageaccount_name = length("${local.storage_name_prefix}sacloudshell") <= 24 ? "${local.storage_name_prefix}sacloudshell" : "${var.location_abbreviation}mp${var.app_abbreviation}sacloudshell"
-  default_ars_storageaccount_name        = "${replace(var.resource_prefix, "-", "")}saarsvault"
-  default_docs_storageaccount_name       = "${replace(var.resource_prefix, "-", "")}docs"
-  default_flowlogs_storageaccount_name   = "${replace(var.resource_prefix, "-", "")}saflowlogs"
-  default_installs_storageaccount_name   = "${replace(var.resource_prefix, "-", "")}sainstalls"
-  default_vmdiag_storageaccount_name     = "${replace(var.resource_prefix, "-", "")}savmdiag"
-  default_network_watcher_name           = "${replace(var.resource_prefix, "-", "_")}_netw_watcher"
+  compute_gallery_name           = var.compute_gallery_name != "default" ? var.compute_gallery_name : "${replace(var.resource_prefix, "-", "_")}_imagegallery_1"
+  cloudshell_storageaccount_name = var.cloudshell_storageaccount_name != "default" ? var.cloudshell_storageaccount_name : length("${local.storage_name_prefix}sacloudshell") <= 24 ? "${local.storage_name_prefix}sacloudshell" : "${var.location_abbreviation}mp${var.app_abbreviation}sacloudshell"
+  ars_storageaccount_name        = var.ars_storageaccount_name != "default" ? var.ars_storageaccount_name : "${replace(var.resource_prefix, "-", "")}saarsvault"
+  docs_storageaccount_name       = var.docs_storageaccount_name != "default" ? var.docs_storageaccount_name : "${replace(var.resource_prefix, "-", "")}docs"
+  flowlogs_storageaccount_name   = var.flowlogs_storageaccount_name != "default" ? var.flowlogs_storageaccount_name : "${replace(var.resource_prefix, "-", "")}saflowlogs"
+  installs_storageaccount_name   = var.installs_storageaccount_name != "default" ? var.installs_storageaccount_name : "${replace(var.resource_prefix, "-", "")}sainstalls"
+  vmdiag_storageaccount_name     = var.vmdiag_storageaccount_name != "default" ? var.vmdiag_storageaccount_name : "${replace(var.resource_prefix, "-", "")}savmdiag"
+  network_watcher_name           = var.network_watcher_name != "default" ? var.network_watcher_name : "${replace(var.resource_prefix, "-", "_")}_netw_watcher"
 }

--- a/network_watcher.tf
+++ b/network_watcher.tf
@@ -1,5 +1,5 @@
 resource "azurerm_network_watcher" "fr_network_watcher" {
-  name                = var.network_watcher_name
+  name                = local.network_watcher_name
   location            = var.location
   resource_group_name = azurerm_resource_group.network.name
 

--- a/network_watcher.tf
+++ b/network_watcher.tf
@@ -1,5 +1,5 @@
 resource "azurerm_network_watcher" "fr_network_watcher" {
-  name                = "${replace(var.resource_prefix, "-", "_")}_netw_watcher"
+  name                = var.network_watcher_name
   location            = var.location
   resource_group_name = azurerm_resource_group.network.name
 

--- a/share_cloudshell.tf
+++ b/share_cloudshell.tf
@@ -9,7 +9,7 @@ resource "azurerm_storage_account" "cloudShell" {
   allow_nested_items_to_be_public = false
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
     ignore_changes = [
       customer_managed_key # required by https://github.com/hashicorp/terraform-provider-azurerm/issues/16085
     ]

--- a/share_cloudshell.tf
+++ b/share_cloudshell.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "cloudShell" {
-  name                            = var.cloudshell_storageaccount_name
+  name                            = local.cloudshell_storageaccount_name
   resource_group_name             = azurerm_resource_group.management.name
   location                        = var.location
   account_tier                    = "Standard"

--- a/share_cloudshell.tf
+++ b/share_cloudshell.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "cloudShell" {
-  name                            = length("${local.storage_name_prefix}sacloudshell") <= 24 ? "${local.storage_name_prefix}sacloudshell" : "${var.location_abbreviation}mp${var.app_abbreviation}sacloudshell"
+  name                            = var.cloudshell_storageaccount_name
   resource_group_name             = azurerm_resource_group.management.name
   location                        = var.location
   account_tier                    = "Standard"

--- a/variables.tf
+++ b/variables.tf
@@ -124,3 +124,8 @@ variable "vmdiag_storageaccount_name" {
   description = "(Optional) Custom name for the VM Diagnostic Logs Storage Account"
   default     = "${replace(var.resource_prefix, "-", "")}savmdiag"
 }
+variable "network_watcher_name" {
+  type        = string
+  description = "(Optional) Custom name for the Azure Network Watcher"
+  default     = "${replace(var.resource_prefix, "-", "_")}_netw_watcher"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -92,40 +92,89 @@ variable "additional_resource_groups" {
 variable "compute_gallery_name" {
   type        = string
   description = "(Optional) Custom name for the Azure Compute Gallery (Shared Image Gallery)"
-  default     = local.default_compute_gallery_name
+  default     = "default"
 }
 variable "cloudshell_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the Cloudshell Storage Account"
-  default     = local.default_cloudshell_storageaccount_name
+  default     = "default"
+  validation {
+    condition     = length(var.cloudshell_storageaccount_name) < 25 && length(var.cloudshell_storageaccount_name) > 2
+    error_message = "Storage account names must be between 3 and 24 characters in length"
+  }
+  validation {
+    condition     = can(regex("^[0-9a-z]+$", var.cloudshell_storageaccount_name))
+    error_message = "Storage account names must contain only lowercase letters and numbers"
+  }
 }
 variable "ars_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the ars Storage Account"
-  default     = local.default_ars_storageaccount_name
+  default     = "default"
+  validation {
+    condition     = length(var.ars_storageaccount_name) < 25 && length(var.ars_storageaccount_name) > 2
+    error_message = "Storage account names must be between 3 and 24 characters in length"
+  }
+  validation {
+    condition     = can(regex("^[0-9a-z]+$", var.ars_storageaccount_name))
+    error_message = "Storage account names must contain only lowercase letters and numbers"
+  }
 }
 variable "docs_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the Documents Storage Account"
-  default     = local.default_docs_storageaccount_name
+  default     = "default"
+  validation {
+    condition     = length(var.docs_storageaccount_name) < 25 && length(var.docs_storageaccount_name) > 2
+    error_message = "Storage account names must be between 3 and 24 characters in length"
+  }
+  validation {
+    condition     = can(regex("^[0-9a-z]+$", var.docs_storageaccount_name))
+    error_message = "Storage account names must contain only lowercase letters and numbers"
+  }
 }
 variable "flowlogs_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the Flow Logs Storage Account"
-  default     = local.default_flowlogs_storageaccount_name
+  default     = "default"
+  validation {
+    condition     = length(var.flowlogs_storageaccount_name) < 25 && length(var.flowlogs_storageaccount_name) > 2
+    error_message = "Storage account names must be between 3 and 24 characters in length"
+  }
+  validation {
+    condition     = can(regex("^[0-9a-z]+$", var.flowlogs_storageaccount_name))
+    error_message = "Storage account names must contain only lowercase letters and numbers"
+  }
 }
 variable "installs_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the Installs Storage Account"
-  default     = local.default_installs_storageaccount_name
+  default     = "default"
+  validation {
+    condition     = length(var.installs_storageaccount_name) < 25 && length(var.installs_storageaccount_name) > 2
+    error_message = "Storage account names must be between 3 and 24 characters in length"
+  }
+  validation {
+    condition     = can(regex("^[0-9a-z]+$", var.installs_storageaccount_name))
+    error_message = "Storage account names must contain only lowercase letters and numbers"
+  }
 }
 variable "vmdiag_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the VM Diagnostic Logs Storage Account"
-  default     = local.default_vmdiag_storageaccount_name
+  default     = "default"
+  validation {
+    condition     = length(var.vmdiag_storageaccount_name) < 25 && length(var.vmdiag_storageaccount_name) > 2
+    error_message = "Storage account names must be between 3 and 24 characters in length"
+  }
+  validation {
+    condition     = can(regex("^[0-9a-z]+$", var.vmdiag_storageaccount_name))
+    error_message = "Storage account names must contain only lowercase letters and numbers"
+  }
 }
 variable "network_watcher_name" {
   type        = string
   description = "(Optional) Custom name for the Azure Network Watcher"
-  default     = local.default_network_watcher_name
+  default     = "default"
+
 }

--- a/variables.tf
+++ b/variables.tf
@@ -92,40 +92,40 @@ variable "additional_resource_groups" {
 variable "compute_gallery_name" {
   type        = string
   description = "(Optional) Custom name for the Azure Compute Gallery (Shared Image Gallery)"
-  default     = "${replace(var.resource_prefix, "-", "_")}_imagegallery_1"
+  default     = local.default_compute_gallery_name
 }
 variable "cloudshell_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the Cloudshell Storage Account"
-  default     = length("${local.storage_name_prefix}sacloudshell") <= 24 ? "${local.storage_name_prefix}sacloudshell" : "${var.location_abbreviation}mp${var.app_abbreviation}sacloudshell"
+  default     = local.default_cloudshell_storageaccount_name
 }
 variable "ars_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the ars Storage Account"
-  default     = "${replace(var.resource_prefix, "-", "")}saarsvault"
+  default     = local.default_ars_storageaccount_name
 }
 variable "docs_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the Documents Storage Account"
-  default     = "${replace(var.resource_prefix, "-", "")}docs"
+  default     = local.default_docs_storageaccount_name
 }
 variable "flowlogs_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the Flow Logs Storage Account"
-  default     = "${replace(var.resource_prefix, "-", "")}saflowlogs"
+  default     = local.default_flowlogs_storageaccount_name
 }
 variable "installs_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the Installs Storage Account"
-  default     = "${replace(var.resource_prefix, "-", "")}sainstalls"
+  default     = local.default_installs_storageaccount_name
 }
 variable "vmdiag_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the VM Diagnostic Logs Storage Account"
-  default     = "${replace(var.resource_prefix, "-", "")}savmdiag"
+  default     = local.default_vmdiag_storageaccount_name
 }
 variable "network_watcher_name" {
   type        = string
   description = "(Optional) Custom name for the Azure Network Watcher"
-  default     = "${replace(var.resource_prefix, "-", "_")}_netw_watcher"
+  default     = local.default_network_watcher_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -176,5 +176,4 @@ variable "network_watcher_name" {
   type        = string
   description = "(Optional) Custom name for the Azure Network Watcher"
   default     = "default"
-
 }

--- a/variables.tf
+++ b/variables.tf
@@ -89,6 +89,11 @@ variable "additional_resource_groups" {
 }
 
 # Optional custom name inputs
+variable "compute_gallery_name" {
+  type        = string
+  description = "(Optional) Custom name for the Azure Compute Gallery (Shared Image Gallery)"
+  default     = "${replace(var.resource_prefix, "-", "_")}_imagegallery_1"
+}
 variable "cloudshell_storageaccount_name" {
   type        = string
   description = "(Optional) Custom name for the Cloudshell Storage Account"

--- a/variables.tf
+++ b/variables.tf
@@ -87,3 +87,35 @@ variable "additional_resource_groups" {
   description = "Additional resource groups to create"
   default     = []
 }
+
+# Optional custom name inputs
+variable "cloudshell_storageaccount_name" {
+  type        = string
+  description = "(Optional) Custom name for the Cloudshell Storage Account"
+  default     = length("${local.storage_name_prefix}sacloudshell") <= 24 ? "${local.storage_name_prefix}sacloudshell" : "${var.location_abbreviation}mp${var.app_abbreviation}sacloudshell"
+}
+variable "ars_storageaccount_name" {
+  type        = string
+  description = "(Optional) Custom name for the ars Storage Account"
+  default     = "${replace(var.resource_prefix, "-", "")}saarsvault"
+}
+variable "docs_storageaccount_name" {
+  type        = string
+  description = "(Optional) Custom name for the Documents Storage Account"
+  default     = "${replace(var.resource_prefix, "-", "")}docs"
+}
+variable "flowlogs_storageaccount_name" {
+  type        = string
+  description = "(Optional) Custom name for the Flow Logs Storage Account"
+  default     = "${replace(var.resource_prefix, "-", "")}saflowlogs"
+}
+variable "installs_storageaccount_name" {
+  type        = string
+  description = "(Optional) Custom name for the Installs Storage Account"
+  default     = "${replace(var.resource_prefix, "-", "")}sainstalls"
+}
+variable "vmdiag_storageaccount_name" {
+  type        = string
+  description = "(Optional) Custom name for the VM Diagnostic Logs Storage Account"
+  default     = "${replace(var.resource_prefix, "-", "")}savmdiag"
+}


### PR DESCRIPTION
- Added optional input variables for the following:
  -  compute_gallery_name         
  -  cloudshell_storageaccount_name 
  -  ars_storageaccount_name             
  -  flowlogs_storageaccount_name  
  -   installs_storageaccount_name  
  -   vmdiag_storageaccount_name     
  -   network_watcher_name
- If these variables are not set, the input variable is passed into locals.tf and replaced with its previously hardcoded value
- This update introduces no breaking changes from v1.0.1 ; existing pak deployments using v1.0.01 will be unaffected if updated to this version
- Storage account names have validation set to constrain inputs to 3-24 characters and lowercase/numbers only
- Updated README to document additional input vars