### PR TITLE
restored  virtual_network_subnet_ids  as an optional variable

### DIFF
--- a/blob_ars.tf
+++ b/blob_ars.tf
@@ -6,7 +6,8 @@ module "ars_sa" {
   account_kind          = "StorageV2"
   ip_rules              = var.ip_for_remote_access
   diag_log_analytics_id = var.diag_log_analytics_id
-  #virtual_network_subnet_ids = var.fw_virtual_network_subnet_ids
+  virtual_network_subnet_ids = var.fw_virtual_network_subnet_ids
+
   tags = merge({
     Function = "Storage"
     Plane    = "Management"
@@ -16,3 +17,5 @@ module "ars_sa" {
   enable_customer_managed_key   = true
   cmk_key_vault_id              = var.core_kv_id
 }
+
+


### PR DESCRIPTION
## Summary :hammer_and_wrench:

This PR re-enables the `virtual_network_subnet_ids` configuration in `blob_ars.tf` by uncommenting the following line:

```hcl
virtual_network_subnet_ids = var.fw_virtual_network_subnet_ids
```

## Purpose :memo:
Uncommenting this line allows storage accounts to accept traffic from specified virtual networks, enabling network-based access controls for enhanced security.

## Testing :rocket:
This change has been tested:

With values provided for fw_virtual_network_subnet_ids: Confirmed that the storage account allows traffic from the defined virtual networks.

Without values: Confirmed that the configuration behaves gracefully with no unintended side effects.

## Impact :package:
Enables support for virtual network rules on storage accounts while maintaining backward compatibility when the variable is not defined.
