### PR TITLE
add input var for storage account public access and default to previo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ vm_image_definitions = {
 | <a name="input_core_kv_id"></a> [core\_kv\_id](#input\_core\_kv\_id) | n/a | `string` | n/a | yes |
 | <a name="input_diag_log_analytics_id"></a> [diag\_log\_analytics\_id](#input\_diag\_log\_analytics\_id) | ID of the Log Analytics Workspace diagnostic logs should be sent to | `string` | n/a | yes |
 | <a name="input_docs_storageaccount_name"></a> [docs\_storageaccount\_name](#input\_docs\_storageaccount\_name) | (Optional) Custom name for the Documents Storage Account | `string` | `"default"` | no |
+| <a name="input_enable_sa_public_access"></a> [enable\_sa\_public\_access](#input\_enable\_sa\_public\_access) | n/a | `bool` | `true` | no |
 | <a name="input_file_upload_paths"></a> [file\_upload\_paths](#input\_file\_upload\_paths) | A list of paths to files which will be uploaded to the installs storage account | `list(string)` | `[]` | no |
 | <a name="input_flowlogs_storageaccount_name"></a> [flowlogs\_storageaccount\_name](#input\_flowlogs\_storageaccount\_name) | (Optional) Custom name for the Flow Logs Storage Account | `string` | `"default"` | no |
 | <a name="input_fw_virtual_network_subnet_ids"></a> [fw\_virtual\_network\_subnet\_ids](#input\_fw\_virtual\_network\_subnet\_ids) | List of subnet ids for the firewall | `list(string)` | `[]` | no |

--- a/blob_ars.tf
+++ b/blob_ars.tf
@@ -1,11 +1,11 @@
 module "ars_sa" {
-  source                = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
-  name                  = local.ars_storageaccount_name
-  resource_group_name   = azurerm_resource_group.management.name
-  location              = var.location
-  account_kind          = "StorageV2"
-  ip_rules              = var.ip_for_remote_access
-  diag_log_analytics_id = var.diag_log_analytics_id
+  source                     = "github.com/Coalfire-CF/terraform-azurerm-storage-account?ref=v1.0.1"
+  name                       = local.ars_storageaccount_name
+  resource_group_name        = azurerm_resource_group.management.name
+  location                   = var.location
+  account_kind               = "StorageV2"
+  ip_rules                   = var.ip_for_remote_access
+  diag_log_analytics_id      = var.diag_log_analytics_id
   virtual_network_subnet_ids = var.fw_virtual_network_subnet_ids
 
   tags = merge({
@@ -13,7 +13,7 @@ module "ars_sa" {
     Plane    = "Management"
   }, var.global_tags, var.regional_tags)
 
-  public_network_access_enabled = true
+  public_network_access_enabled = var.enable_sa_public_access
   enable_customer_managed_key   = true
   cmk_key_vault_id              = var.core_kv_id
 }

--- a/blob_docs.tf
+++ b/blob_docs.tf
@@ -12,7 +12,7 @@ module "docs_sa" {
     Plane    = "Management"
   }, var.global_tags, var.regional_tags)
 
-  public_network_access_enabled = true
+  public_network_access_enabled = var.enable_sa_public_access
   enable_customer_managed_key   = true
   cmk_key_vault_id              = var.core_kv_id
   storage_containers = [

--- a/blob_flowlog.tf
+++ b/blob_flowlog.tf
@@ -12,7 +12,7 @@ module "flowlogs_sa" {
     Plane    = "Management"
   }, var.global_tags, var.regional_tags)
 
-  public_network_access_enabled = true
+  public_network_access_enabled = var.enable_sa_public_access
   enable_customer_managed_key   = true
   cmk_key_vault_id              = var.core_kv_id
 }

--- a/blob_install.tf
+++ b/blob_install.tf
@@ -12,7 +12,7 @@ module "installs_sa" {
     Plane    = "Management"
   }, var.global_tags, var.regional_tags)
 
-  public_network_access_enabled = true
+  public_network_access_enabled = var.enable_sa_public_access
   enable_customer_managed_key   = true
   cmk_key_vault_id              = var.core_kv_id
   storage_containers = [

--- a/blob_vm_diag.tf
+++ b/blob_vm_diag.tf
@@ -12,7 +12,7 @@ module "vm_diag" {
     Plane    = "Management"
   }, var.global_tags, var.regional_tags)
 
-  public_network_access_enabled = true
+  public_network_access_enabled = var.enable_sa_public_access
   enable_customer_managed_key   = true
   cmk_key_vault_id              = var.core_kv_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -195,3 +195,8 @@ variable "vm_image_definitions" {
   }))
   default = []
 }
+
+variable "enable_sa_public_access" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
This PR adds an optional variable input, `enable_sa_public_access`, to disable or enable public network access on the four storage accounts created by region-setup. 

Exposing this configuration setting as an input variable allows more flexibility when deploying for customers with strict requirements for storage account network access. 

It also allows the storage accounts to be deployed initially with public access open, then updated later on to block public network access when a VPN is in place.

If the var is left undefined, it defaults to the previously hardcoded value of `true`. This ensures that existing deployments will be unaffected.