### PR TITLE
chore: refresh PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,73 +1,30 @@
-# Pull Request Checklist
+## Summary
 
-> Please take a moment to review this checklist carefully — only check items that genuinely apply. This helps maintain code quality, traceability, and review integrity.
+{Quick summary of what this PR does and why. If it is a breaking change or adds
+new behavior, note what consumers need to do. Delete the braces when done.}
 
----
+Closes #{issue number, or delete this line if none}
 
-## Admin
-- [ ] **Required:** I have read the [contributing guidelines](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/2648440862/Pull+Request+Best+Practices) for submitting a PR.
+## Type of change
 
----
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change
+- [ ] Docs / chore
 
-## Types of Changes (Required Conventional Commits)
-> We follow **Conventional Commits** to keep history readable and automate changelogs/releases.  
-> Use `!` after the type (e.g., `feat!:` or `fix!:`) to indicate a **breaking change**.
+## How this was tested
 
-- [ ] **feat:** Introduces a new feature or capability for users.
-- [ ] **fix:** Resolves a bug or unintended behavior.
-- [ ] **chore:** Maintenance or tooling changes that don’t affect runtime behavior.
-- [ ] **docs:** Documentation-only changes (README, comments, wiki, etc.).
-- [ ] **refactor:** Code restructuring that doesn’t change functionality.
-- [ ] **test:** Adds or updates tests without changing production code.
-- [ ] **ci:** Updates to CI/CD pipelines or automation workflows.
+{Commands you ran and where, e.g. `terraform apply` in a Coalfire sandbox,
+`terratest`, `packer build`. Note anything a reviewer should re-run.}
 
----
+## Checklist
 
-## AI Assistance Disclosure (Required)
-> We encourage responsible AI usage. Disclosure helps reviewers apply extra scrutiny to prevent hallucinations, logic errors, or insecure patterns.
+- [ ] I understand these changes and have tested them; they work (not pasted in unreviewed).
+- [ ] All GitHub Actions passed, or I noted any failures above.
+- [ ] `README.md` / relevant docs updated if behavior changed.
+- [ ] PR title uses the [standard commit format][rp] (feeds release-please).
+- [ ] Reviewer and assignee tagged.
 
-- [ ] **I used AI assistance while creating this PR**
-- [ ] **I did NOT use AI assistance for this PR**
+<sub>New to the process? See the [Release Process guide][rp] for commit and PR standards.</sub>
 
-If AI was used, briefly describe:
-- What tools were used (e.g., ChatGPT, Copilot, Claude)
-- What it helped with (e.g., refactoring, test generation, docs)
-- Any areas that may require extra review
-
-<!-- Example: “Used ChatGPT to refactor Terraform locals — manually validated logic and security.” -->
-
----
-
-## Testing
-
-- [ ] **Required:** I tested the proposed changes (e.g., `terraform apply`, `packer build`, app runtime tests).
-- [ ] **Required:** All GitHub Actions checks passed, or failures are documented in the PR description.
-- [ ] **Optional:** I have already deployed or validated this change in a real environment.
-
-### Tested In:
-- [ ] Local development environment
-- [ ] Customer environment
-- [ ] Coalfire Sandbox (AWS GovCloud, Azure Gov, GCP, etc.)
-
----
-
-## Documentation
-
-- [ ] **Recommended:** Updated ***README.md*** where applicable
-- [ ] **Recommended:** Updated relevant ***Confluence / Wiki*** documentation
-- [ ] **Recommended:** Added inline comments or context for complex logic
-
----
-
-## Tagging / Ownership
-
-- [ ] **Required:** Reviewer(s) assigned
-- [ ] **Required:** Assignee(s) assigned
-- [ ] **Optional:** Relevant stakeholders notified via comment
-
----
-
-## Optional: Reviewer Guidance
-> Call out risky areas, architectural decisions, or areas needing deeper review.
-
-<!-- Example: “Please focus review on auth middleware changes and IAM policy updates.” -->
+[rp]: https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/3496312888/Release+Process


### PR DESCRIPTION
Standardizes `.github/PULL_REQUEST_TEMPLATE.md` to the current org default (summary-first, trimmed checklist). Opened by scripts/pr-template-sweep.sh.